### PR TITLE
feat(web): add widget demo and fix navigation

### DIFF
--- a/packages/nextjs/components/BotBlockWidget/BotBlockWidget.tsx
+++ b/packages/nextjs/components/BotBlockWidget/BotBlockWidget.tsx
@@ -1,0 +1,18 @@
+export const BotBlockWidget = ({ planId }: { planId: string }) => {
+  // const linkUrl = "https://www.botblock.io/subscribe/";
+  const linkUrl = `https://botblock-3805ec.spheron.app/subscribe/${planId}`;
+  const buttonText = "Go to Botblock to authorize crawler";
+  return (
+    <button
+      style={{
+        borderWidth: 1,
+        borderColor: "#000",
+        borderRadius: 8,
+        padding: 4,
+      }}
+      onClick={() => (window.location.href = `${linkUrl}`)}
+    >
+      {buttonText}
+    </button>
+  );
+};

--- a/packages/nextjs/components/unlock/CodeSnippet.tsx
+++ b/packages/nextjs/components/unlock/CodeSnippet.tsx
@@ -1,11 +1,21 @@
 import React, { useState } from "react";
 import { ClipboardIcon } from "@heroicons/react/24/solid";
 
-const CodeSnippetButton = () => {
+const CodeSnippetButton = ({ planId }: { planId: string }) => {
   const [isCopied, setIsCopied] = useState(false);
-  const linkUrl = "https://www.botblock.com";
+  const linkUrl = `https://botblock-3805ec.spheron.app/subscribe/${planId}`;
   const buttonText = "Go to Botblock to authorize crawler";
-  const codeToCopy = `<button onclick="window.location.href='${linkUrl}'">${buttonText}</button>`;
+  const codeToCopy = `<button
+  style={{
+    borderWidth: 1,
+    borderColor: "#000",
+    borderRadius: 8,
+    padding: 4,
+  }}
+  onclick="window.location.href='${linkUrl}'"
+>
+${buttonText}
+</button>`;
 
   const handleCopyClick = () => {
     navigator.clipboard.writeText(codeToCopy);
@@ -28,7 +38,7 @@ const CodeSnippetButton = () => {
         </div>
       )}
       <pre
-        className="bg-gray-800 p-4 rounded-md text-white overflow-x-auto"
+        className="bg-gray-800 p-4 rounded-md text-white overflow-x-auto flex-wrap"
         onClick={handleCopyClick}
         style={{ cursor: "pointer" }}
       >

--- a/packages/nextjs/pages/unlock/partner/confirm.tsx
+++ b/packages/nextjs/pages/unlock/partner/confirm.tsx
@@ -1,3 +1,4 @@
+import { useRouter } from "next/router";
 import { Button } from "~~/components/Button";
 import PlanDetailsBox from "~~/components/PlanDetailsBox";
 import { useWeb3AuthContext } from "~~/context/Web3AuthContext";
@@ -7,6 +8,7 @@ const TITLE = "Confirm data and create a new plan";
 const DESCRIPTION = "Have a last check to the plan. when clicking confirm, the plan will be listed on Botblock market.";
 
 const Confirm = () => {
+  const router = useRouter();
   const { plan, connectedSubsContract } = useWeb3AuthContext();
 
   const handleCreatePlan = async () => {
@@ -21,6 +23,7 @@ const Confirm = () => {
           notification.success(`Transaction with hash ${tx?.hash} completed successfully!`, {
             icon: "🎉",
           });
+          router.push("/unlock/partner/next-steps");
         }
       } else {
         notification.error("you need to log in first");
@@ -35,7 +38,9 @@ const Confirm = () => {
       <h1 className="text-4xl sm:text-6xl">{TITLE}</h1>
       <h3 className="text-xl sm:text-2xl">{DESCRIPTION}</h3>
       <div className="grid grid-cols-2 gap-4">{plan && <PlanDetailsBox title={"Recap"} plan={plan} />}</div>
-      <Button title={"Create Plan"} onClick={handleCreatePlan} />
+      <div className="flex flex-row">
+        <Button title={"Create Plan"} onClick={handleCreatePlan} />
+      </div>
     </div>
   );
 };

--- a/packages/nextjs/pages/unlock/partner/next-steps.tsx
+++ b/packages/nextjs/pages/unlock/partner/next-steps.tsx
@@ -1,5 +1,7 @@
+import { useEffect, useState } from "react";
 import { BotBlockWidget } from "~~/components/BotBlockWidget/BotBlockWidget";
 import CodeSnippetButton from "~~/components/unlock/CodeSnippet";
+import { Plan } from "~~/context/Types";
 import { useWeb3AuthContext } from "~~/context/Web3AuthContext";
 
 const TITLE = "Next Steps";
@@ -9,7 +11,18 @@ const STEP_THREE = "Place the widget on your site to guide AI devs to Botblock f
 const WIDGET_EXPLANATION = "If used as it is shared, it will look and work as the one shown below";
 
 const NextSteps = () => {
-  const { email } = useWeb3AuthContext();
+  const { address, email, getPlans } = useWeb3AuthContext();
+  const [latestPlanCreated, setLatestPlanCreated] = useState<Plan>();
+
+  useEffect(() => {
+    const getLatestPlanIdOfUser = async () => {
+      const plans = await getPlans();
+      setLatestPlanCreated(plans?.findLast(plan => plan.contentCreator === address));
+    };
+
+    getLatestPlanIdOfUser();
+  }, [address, getPlans]);
+
   return (
     <div className="p-32 flex-grow" data-theme="exampleUi">
       <h1 className="text-4xl sm:text-6xl">{TITLE}</h1>
@@ -35,7 +48,7 @@ const NextSteps = () => {
       <br />
 
       <div className="col-span-2 md:col-span-1 flex items-center justify-center">
-        <CodeSnippetButton planId="8" />
+        <CodeSnippetButton planId={latestPlanCreated?.planId as string} />
       </div>
 
       <br />
@@ -43,7 +56,7 @@ const NextSteps = () => {
         <h3 className="text-md sm:text-xl pl-3">{WIDGET_EXPLANATION}</h3>
       </div>
       <div className="flex justify-center py-8">
-        <BotBlockWidget planId="8" />
+        <BotBlockWidget planId={latestPlanCreated?.planId as string} />
       </div>
     </div>
   );

--- a/packages/nextjs/pages/unlock/partner/next-steps.tsx
+++ b/packages/nextjs/pages/unlock/partner/next-steps.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { BotBlockWidget } from "~~/components/BotBlockWidget/BotBlockWidget";
+import { Web3AuthConnectButton } from "~~/components/Header/components/Web3AuthConnectButton";
 import CodeSnippetButton from "~~/components/unlock/CodeSnippet";
 import { Plan } from "~~/context/Types";
 import { useWeb3AuthContext } from "~~/context/Web3AuthContext";
@@ -11,7 +12,7 @@ const STEP_THREE = "Place the widget on your site to guide AI devs to Botblock f
 const WIDGET_EXPLANATION = "If used as it is shared, it will look and work as the one shown below";
 
 const NextSteps = () => {
-  const { address, email, getPlans } = useWeb3AuthContext();
+  const { address, email, getPlans, isConnected } = useWeb3AuthContext();
   const [latestPlanCreated, setLatestPlanCreated] = useState<Plan>();
 
   useEffect(() => {
@@ -25,39 +26,52 @@ const NextSteps = () => {
 
   return (
     <div className="p-32 flex-grow" data-theme="exampleUi">
-      <h1 className="text-4xl sm:text-6xl">{TITLE}</h1>
+      <h1 className="text-4xl sm:text-6xl">
+        {!isConnected
+          ? "Please log in to see this page"
+          : latestPlanCreated
+          ? TITLE
+          : "There are no plans created under this account"}
+      </h1>
+      {!isConnected ? (
+        <Web3AuthConnectButton />
+      ) : latestPlanCreated ? (
+        <>
+          <div className="flex flex-col">
+            <div className="flex items-center mb-4">
+              <span className="text-gray-600 font-bold px-3 border-r border-gray-600">Step 1</span>
+              <h3 className="text-xl sm:text-2xl pl-3">{STEP_ONE}</h3>
+            </div>
 
-      <div className="flex flex-col">
-        <div className="flex items-center mb-4">
-          <span className="text-gray-600 font-bold px-3 border-r border-gray-600">Step 1</span>
-          <h3 className="text-xl sm:text-2xl pl-3">{STEP_ONE}</h3>
-        </div>
+            <div className="font-bold  text-center">Your Email is {email}</div>
+          </div>
+          <br />
+          <div className="flex items-center">
+            <span className="text-gray-600 font-bold px-3 border-r border-gray-600">Step 2</span>
+            <h3 className="text-xl sm:text-2xl pl-3">{STEP_TWO}</h3>
+          </div>
+          <br />
+          <div className="flex items-center">
+            <span className="text-gray-600 font-bold px-3 border-r border-gray-600">Step 3</span>
+            <h3 className="text-xl sm:text-2xl pl-3">{STEP_THREE}</h3>
+          </div>
+          <br />
 
-        <div className="font-bold  text-center">Your Email is {email}</div>
-      </div>
-      <br />
-      <div className="flex items-center">
-        <span className="text-gray-600 font-bold px-3 border-r border-gray-600">Step 2</span>
-        <h3 className="text-xl sm:text-2xl pl-3">{STEP_TWO}</h3>
-      </div>
-      <br />
-      <div className="flex items-center">
-        <span className="text-gray-600 font-bold px-3 border-r border-gray-600">Step 3</span>
-        <h3 className="text-xl sm:text-2xl pl-3">{STEP_THREE}</h3>
-      </div>
-      <br />
+          <div className="col-span-2 md:col-span-1 flex items-center justify-center">
+            <CodeSnippetButton planId={latestPlanCreated?.planId as string} />
+          </div>
 
-      <div className="col-span-2 md:col-span-1 flex items-center justify-center">
-        <CodeSnippetButton planId={latestPlanCreated?.planId as string} />
-      </div>
-
-      <br />
-      <div className="flex items-center">
-        <h3 className="text-md sm:text-xl pl-3">{WIDGET_EXPLANATION}</h3>
-      </div>
-      <div className="flex justify-center py-8">
-        <BotBlockWidget planId={latestPlanCreated?.planId as string} />
-      </div>
+          <br />
+          <div className="flex items-center">
+            <h3 className="text-md sm:text-xl pl-3">{WIDGET_EXPLANATION}</h3>
+          </div>
+          <div className="flex justify-center py-8">
+            <BotBlockWidget planId={latestPlanCreated?.planId as string} />
+          </div>
+        </>
+      ) : (
+        <></>
+      )}
     </div>
   );
 };

--- a/packages/nextjs/pages/unlock/partner/next-steps.tsx
+++ b/packages/nextjs/pages/unlock/partner/next-steps.tsx
@@ -1,3 +1,4 @@
+import { BotBlockWidget } from "~~/components/BotBlockWidget/BotBlockWidget";
 import CodeSnippetButton from "~~/components/unlock/CodeSnippet";
 import { useWeb3AuthContext } from "~~/context/Web3AuthContext";
 
@@ -5,6 +6,7 @@ const TITLE = "Next Steps";
 const STEP_ONE = "Check your email with the instructions to update the robots.txt";
 const STEP_TWO = "Botblock will automatically check the update on your robots.txt and send you the subscription money";
 const STEP_THREE = "Place the widget on your site to guide AI devs to Botblock for subscription purchases";
+const WIDGET_EXPLANATION = "If used as it is shared, it will look and work as the one shown below";
 
 const NextSteps = () => {
   const { email } = useWeb3AuthContext();
@@ -33,7 +35,15 @@ const NextSteps = () => {
       <br />
 
       <div className="col-span-2 md:col-span-1 flex items-center justify-center">
-        <CodeSnippetButton />
+        <CodeSnippetButton planId="8" />
+      </div>
+
+      <br />
+      <div className="flex items-center">
+        <h3 className="text-md sm:text-xl pl-3">{WIDGET_EXPLANATION}</h3>
+      </div>
+      <div className="flex justify-center py-8">
+        <BotBlockWidget planId="8" />
       </div>
     </div>
   );

--- a/packages/nextjs/pages/unlock/partner/next-steps.tsx
+++ b/packages/nextjs/pages/unlock/partner/next-steps.tsx
@@ -4,8 +4,7 @@ import { useWeb3AuthContext } from "~~/context/Web3AuthContext";
 const TITLE = "Next Steps";
 const STEP_ONE = "Check your email with the instructions to update the robots.txt";
 const STEP_TWO = "Botblock will automatically check the update on your robots.txt and send you the subscription money";
-const STEP_THREE =
-  "Place the widget on your site to guide AI devs to Botblock for subscription purchases";
+const STEP_THREE = "Place the widget on your site to guide AI devs to Botblock for subscription purchases";
 
 const NextSteps = () => {
   const { email } = useWeb3AuthContext();


### PR DESCRIPTION
## Description

Content creators need to share their subscription plans to AI devs/companies to be able to monetize their content from scrappers.

This PR does:
- Add the button showed on the code so users can test it
- Add next-steps navigation after confirmation of plan creation
- Ask for log in to see info
- Check for latest plan