### PR TITLE
feat(nvm): add query asset function to nvm ctx and add example to app

### DIFF
--- a/packages/nextjs/pages/index.tsx
+++ b/packages/nextjs/pages/index.tsx
@@ -3,8 +3,11 @@ import dynamic from "next/dynamic";
 import { useRouter } from "next/router";
 import { NextPage } from "next";
 import toast from "react-hot-toast";
+import { useAccount } from "wagmi";
+import { LoginButton } from "~~/components";
 import { useRobotsContext } from "~~/context/RobotsContext";
 import { Plan, TokenAddress, tokenAddressMap } from "~~/context/Types";
+import { useNvmContext } from "~~/context/nvm/NvmContext";
 import { useBBContractReads } from "~~/hooks/Botblock";
 import { ContractNames } from "~~/hooks/Botblock/hooksUtils";
 import { palette } from "~~/styles/colors";
@@ -169,11 +172,50 @@ const SubscriptionOverviewSection = () => {
   );
 };
 
+// Component meant to troubleshoot and test the NVM context
+export const NvmTest = () => {
+  const [assets, setAssets] = useState<string[]>();
+  const [shouldQuery, setShouldQuery] = useState(false);
+  const { isConnected } = useAccount();
+  const { queryAssets } = useNvmContext();
+
+  useEffect(() => {
+    if (shouldQuery) {
+      queryAssets()
+        .then(res => {
+          setAssets(res.results.map(asset => asset.service.find(s => s.type === "metadata")?.attributes.main.name));
+        })
+        .catch(err => toast.error(err.message))
+        .finally(() => setShouldQuery(false));
+    }
+  }, [queryAssets, shouldQuery]);
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", padding: "48px" }}>
+      {!isConnected ? (
+        <>
+          <Text>Please log in</Text>
+          <LoginButton />
+        </>
+      ) : (
+        <>
+          <Button onClick={() => setShouldQuery(true)}>Query Assets</Button>
+          {assets?.map((asset, idx) => (
+            <Text key={`${asset}-${idx}`}>{asset}</Text>
+          ))}
+        </>
+      )}
+    </div>
+  );
+};
+
 const Landing: NextPage = () => (
   <div className="flex flex-col">
     <Title />
     <ProtectSection />
     <SubscriptionOverviewSection />
+    {/* Uncomment below to check the NVM test */}
+    {/* <NvmTest /> */}
   </div>
 );
 


### PR DESCRIPTION
## Description

As part of our integration with NVM, we tweaked our context to be able to query for assets.

On this PR we add the function to query and a sample component (commented to avoid potential release of that) that validates the integration is working.

Next up we shall:
- Test the publishing and listing flow for botblock entirely
- Work on forking the node to avoid everyone releasing the funds on their own (and use a trusted validator instead)

## Proof

| _Asset listing_ |
| :---: |
| ![image](https://github.com/keyko-io/botblock-mvp/assets/21087992/1e620763-fc77-4314-bce5-d831bd1a40d4) |

| _Error while trying to publish_ |
| :---: |
| ![image](https://github.com/keyko-io/botblock-mvp/assets/21087992/efcbeb25-b130-48cb-9baf-4881e456f646) |

## Related issues
- #51 
- #74 