### PR TITLE
ref:title component and use next js Image component

### DIFF
--- a/packages/nextjs/pages/index.tsx
+++ b/packages/nextjs/pages/index.tsx
@@ -1,5 +1,6 @@
 import { SVGProps, useEffect, useState } from "react";
 import dynamic from "next/dynamic";
+import Image from "next/image";
 import { useRouter } from "next/router";
 import { NextPage } from "next";
 import toast from "react-hot-toast";
@@ -17,19 +18,10 @@ const ScribbleIcon = dynamic<SVGProps<any>>(() => import("~~/public/assets/icons
 
 const Title = () => {
   return (
-    <div
-      style={{
-        flex: 1,
-        display: "flex",
-        alignItems: "center",
-        padding: "20px 0px",
-      }}
-    >
-      <div className="mx-20 flex flex-col justify-start items-center" style={{ width: 300 }}>
-        <img src="/images/whoyagonnacall.png"></img>
-      </div>
+    <div className="min-h-screen flex items-center mx-auto -translate-y-10 space-x-10">
+      <Image src="/images/whoyagonnacall.png" height={300} width={300} alt="botblock logo png" />
 
-      <div style={{ width: "66%" }}>
+      <div>
         <Text type="h1" style={{ marginBottom: "30px", fontWeight: "bold", textAlign: "left" }}>
           Make AI Crawlers pay for your content...
         </Text>


### PR DESCRIPTION
- Paul added new png for title section , after that i did some small changes and refactoring


 **my changes includes** :

- making the hero section "min-h-screen" 
- adjusting with and flex view
- adding nextjs Image components for the img

<img width="1512" alt="Screenshot 2024-01-04 at 14 02 13" src="https://github.com/keyko-io/botblock-mvp/assets/102976899/c0372a7c-eef8-4ca6-b981-18edcd861ec3">

<img width="1512" alt="Screenshot 2024-01-04 at 14 06 11" src="https://github.com/keyko-io/botblock-mvp/assets/102976899/2009db14-01a4-4ad2-ae11-dd86269a6cd3">

